### PR TITLE
Feat/get image

### DIFF
--- a/src/main/java/org/prography/kagongsillok/common/resolver/AccessTokenArgumentResolver.java
+++ b/src/main/java/org/prography/kagongsillok/common/resolver/AccessTokenArgumentResolver.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.prography.kagongsillok.auth.domain.dto.LoginMemberInfo;
 import org.prography.kagongsillok.auth.infrastructure.JwtAuthTokenProvider;
 import org.prography.kagongsillok.common.resolver.dto.LoginMemberDto;
+import org.prography.kagongsillok.common.resolver.exception.AccessTokenAuthenticationException;
 import org.prography.kagongsillok.member.domain.Role;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -31,6 +32,7 @@ public class AccessTokenArgumentResolver implements HandlerMethodArgumentResolve
         HttpServletRequest httpServletRequest = (HttpServletRequest) webRequest.getNativeRequest();
 
         String accessToken = getAccessToken(httpServletRequest.getHeader("authorization"));
+
         final LoginMemberInfo loginMemberInfo = jwtAuthTokenProvider.getLoginMemberByAccessToken(accessToken);
         final Long memberId = loginMemberInfo.getMemberId();
         final Role role = loginMemberInfo.getRole();
@@ -39,6 +41,9 @@ public class AccessTokenArgumentResolver implements HandlerMethodArgumentResolve
     }
 
     private String getAccessToken(String accessTokenHeader) {
+        if (accessTokenHeader == null) {
+            throw new AccessTokenAuthenticationException();
+        }
         return accessTokenHeader.split(" ")[1];
     }
 }

--- a/src/main/java/org/prography/kagongsillok/common/resolver/exception/AccessTokenAuthenticationException.java
+++ b/src/main/java/org/prography/kagongsillok/common/resolver/exception/AccessTokenAuthenticationException.java
@@ -1,0 +1,10 @@
+package org.prography.kagongsillok.common.resolver.exception;
+
+import org.prography.kagongsillok.auth.application.exception.AuthenticationException;
+
+public class AccessTokenAuthenticationException extends AuthenticationException {
+
+    public AccessTokenAuthenticationException() {
+        super(String.format("Header에 AccessToken이 존재하지 않습니다."));
+    }
+}

--- a/src/main/java/org/prography/kagongsillok/image/domain/ImageRepository.java
+++ b/src/main/java/org/prography/kagongsillok/image/domain/ImageRepository.java
@@ -1,9 +1,10 @@
 package org.prography.kagongsillok.image.domain;
 
 import java.util.List;
+import org.prography.kagongsillok.image.infrastructure.ImageRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ImageRepository extends JpaRepository<Image, Long> {
+public interface ImageRepository extends JpaRepository<Image, Long>, ImageRepositoryCustom {
 
     List<Image> findByIdIn(List<Long> imageIds);
 }

--- a/src/main/java/org/prography/kagongsillok/image/infrastructure/ImageRepositoryCustom.java
+++ b/src/main/java/org/prography/kagongsillok/image/infrastructure/ImageRepositoryCustom.java
@@ -1,0 +1,11 @@
+package org.prography.kagongsillok.image.infrastructure;
+
+import java.util.List;
+import java.util.Map;
+import org.prography.kagongsillok.image.domain.Image;
+
+public interface ImageRepositoryCustom {
+
+    Map<Long, Image> findByIdInToMap(List<Long> imageIds);
+
+}

--- a/src/main/java/org/prography/kagongsillok/image/infrastructure/ImageRepositoryImpl.java
+++ b/src/main/java/org/prography/kagongsillok/image/infrastructure/ImageRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.prography.kagongsillok.image.domain.Image;
@@ -30,7 +31,7 @@ public class ImageRepositoryImpl implements ImageRepositoryCustom{
 
         return images
                 .stream()
-                .collect(Collectors.toMap(Image::getId, i -> i));
+                .collect(Collectors.toMap(Image::getId, Function.identity()));
     }
 
     private BooleanExpression idIn(final List<Long> ids) {

--- a/src/main/java/org/prography/kagongsillok/image/infrastructure/ImageRepositoryImpl.java
+++ b/src/main/java/org/prography/kagongsillok/image/infrastructure/ImageRepositoryImpl.java
@@ -1,6 +1,6 @@
-package org.prography.kagongsillok.member.infrastructure;
+package org.prography.kagongsillok.image.infrastructure;
 
-import static org.prography.kagongsillok.member.domain.QMember.member;
+import static org.prography.kagongsillok.image.domain.QImage.image;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -8,35 +8,36 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.prography.kagongsillok.member.domain.Member;
+import org.prography.kagongsillok.image.domain.Image;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class MemberRepositoryImpl implements MemberRepositoryCustom {
+public class ImageRepositoryImpl implements ImageRepositoryCustom{
 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Map<Long, Member> findByIdIn(final List<Long> memberIds) {
-        final List<Member> members = queryFactory
-                .selectFrom(member)
+    public Map<Long, Image> findByIdInToMap(final List<Long> imageIds) {
+
+        final List<Image> images = queryFactory
+                .selectFrom(image)
                 .where(
-                        idIn(memberIds),
+                        idIn(imageIds),
                         isNotDeleted()
                 )
                 .fetch();
 
-        return members
+        return images
                 .stream()
-                .collect(Collectors.toMap(Member::getId, m -> m));
+                .collect(Collectors.toMap(Image::getId, i -> i));
     }
 
     private BooleanExpression idIn(final List<Long> ids) {
-        return member.id.in(ids);
+        return image.id.in(ids);
     }
 
     private BooleanExpression isNotDeleted() {
-        return member.isDeleted.eq(Boolean.FALSE);
+        return image.isDeleted.eq(Boolean.FALSE);
     }
 }

--- a/src/main/java/org/prography/kagongsillok/member/domain/MemberRepository.java
+++ b/src/main/java/org/prography/kagongsillok/member/domain/MemberRepository.java
@@ -1,7 +1,8 @@
 package org.prography.kagongsillok.member.domain;
 
+import org.prography.kagongsillok.member.infrastructure.MemberRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
 }

--- a/src/main/java/org/prography/kagongsillok/member/infrastructure/MemberRepositoryCustom.java
+++ b/src/main/java/org/prography/kagongsillok/member/infrastructure/MemberRepositoryCustom.java
@@ -1,0 +1,10 @@
+package org.prography.kagongsillok.member.infrastructure;
+
+import java.util.List;
+import org.prography.kagongsillok.member.domain.Member;
+
+public interface MemberRepositoryCustom {
+
+    List<Member> findByIdIn(final List<Long> memberIds);
+
+}

--- a/src/main/java/org/prography/kagongsillok/member/infrastructure/MemberRepositoryCustom.java
+++ b/src/main/java/org/prography/kagongsillok/member/infrastructure/MemberRepositoryCustom.java
@@ -1,10 +1,11 @@
 package org.prography.kagongsillok.member.infrastructure;
 
 import java.util.List;
+import java.util.Map;
 import org.prography.kagongsillok.member.domain.Member;
 
 public interface MemberRepositoryCustom {
 
-    List<Member> findByIdIn(final List<Long> memberIds);
+    Map<Long, Member> findByIdIn(final List<Long> memberIds);
 
 }

--- a/src/main/java/org/prography/kagongsillok/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/org/prography/kagongsillok/member/infrastructure/MemberRepositoryImpl.java
@@ -1,0 +1,37 @@
+package org.prography.kagongsillok.member.infrastructure;
+
+import static org.prography.kagongsillok.member.domain.QMember.member;
+import static org.prography.kagongsillok.place.domain.QPlace.place;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.prography.kagongsillok.member.domain.Member;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Member> findByIdIn(final List<Long> memberIds) {
+        return queryFactory
+                .selectFrom(member)
+                .where(
+                        idIn(memberIds),
+                        isNotDeleted()
+                )
+                .fetch();
+    }
+
+    private BooleanExpression idIn(final List<Long> ids) {
+        return member.id.in(ids);
+    }
+
+    private BooleanExpression isNotDeleted() {
+        return member.isDeleted.eq(Boolean.FALSE);
+    }
+}

--- a/src/main/java/org/prography/kagongsillok/review/application/ReviewService.java
+++ b/src/main/java/org/prography/kagongsillok/review/application/ReviewService.java
@@ -127,13 +127,24 @@ public class ReviewService {
     }
 
     private Member getMappedMember(final Review review, final Map<Long, Member> members) {
-        return members.get(review.getMemberId());
+        Long memberId = review.getMemberId();
+
+        if (!members.containsKey(memberId)) {
+            // 가드 로직: 멤버 ID가 멤버 맵에 존재하지 않으면 null 반환 또는 예외 처리 등을 수행할 수 있습니다.
+            return Member.builder()
+                    .nickname("알 수 없음")
+                    .email("Unknown@unknown.com")
+                    .build();
+        }
+
+        return members.get(memberId);
     }
 
     private List<Image> getMappedImage(final Review review, final Map<Long, Image> images) {
         return review
                 .getImageIds()
                 .stream()
+                .filter(imageId -> images.containsKey(imageId))
                 .map(images::get)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/org/prography/kagongsillok/review/application/ReviewService.java
+++ b/src/main/java/org/prography/kagongsillok/review/application/ReviewService.java
@@ -1,14 +1,21 @@
 package org.prography.kagongsillok.review.application;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.prography.kagongsillok.common.utils.CustomListUtils;
+import org.prography.kagongsillok.image.application.dto.ImageDto;
+import org.prography.kagongsillok.image.domain.Image;
+import org.prography.kagongsillok.image.domain.ImageRepository;
 import org.prography.kagongsillok.member.application.exception.NotFoundMemberException;
 import org.prography.kagongsillok.member.domain.Member;
 import org.prography.kagongsillok.member.domain.MemberRepository;
 import org.prography.kagongsillok.review.application.dto.ReviewCreateCommand;
 import org.prography.kagongsillok.review.application.dto.ReviewDto;
+import org.prography.kagongsillok.review.application.dto.ReviewImageDto;
+import org.prography.kagongsillok.review.application.dto.ReviewImagesInfoDto;
 import org.prography.kagongsillok.review.application.dto.ReviewUpdateCommand;
 import org.prography.kagongsillok.review.application.exception.NotFoundReviewException;
 import org.prography.kagongsillok.review.domain.Review;
@@ -27,6 +34,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ReviewTagRepository reviewTagRepository;
     private final MemberRepository memberRepository;
+    private final ImageRepository imageRepository;
 
     @Transactional
     public ReviewDto createReview(final ReviewCreateCommand reviewCreateCommand) {
@@ -85,5 +93,73 @@ public class ReviewService {
                 .orElseThrow(() -> new NotFoundReviewException(id));
 
         review.delete();
+    }
+
+    public ReviewImagesInfoDto getPlaceReviewImages(final Long placeId) {
+        final List<Review> reviews = reviewRepository.findAllByPlaceId(placeId);
+
+        final List<Long> reviewImageIds = reviews.stream()
+                .map(Review::getImageIds)
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+        final List<Long> memberIds = reviews.stream()
+                .map(Review::getMemberId)
+                .collect(Collectors.toList());
+
+        final List<Image> images = imageRepository.findByIdIn(reviewImageIds);
+        final List<Member> members = memberRepository.findByIdIn(memberIds);
+
+        return ReviewImagesInfoDto.of(
+                reviewImageIds.size(),
+                bindMemberAndImage(reviews, members, images)
+        );
+    }
+
+    private List<ReviewImageDto> bindMemberAndImage(final List<Review> reviews, final List<Member> members,
+            final List<Image> images) {
+
+        List<ReviewImageDto> reviewImageDtos = new ArrayList<>();
+
+        for (Review review : reviews) {
+            reviewImageDtos.addAll(getReviewImageDtos(review, members, images));
+        }
+
+        return reviewImageDtos;
+    }
+
+    private Member getMappedMember(final Review review, final List<Member> members) {
+        return members.stream()
+                .filter(member -> member.getId() == review.getMemberId())
+                .findFirst()
+                .orElse(
+                        Member.builder()
+                                .nickname("알 수 없음")
+                                .email("알 수 없음")
+                                .build()
+                );
+    }
+
+    private List<Image> getMappedImage(final Review review, final List<Image> images) {
+        return images.stream()
+                .filter(
+                        image -> review
+                                .getImageIds()
+                                .contains(image.getId())
+                )
+                .collect(Collectors.toList());
+    }
+
+    private List<ReviewImageDto> getReviewImageDtos(final Review review, final List<Member> members,
+            final List<Image> images) {
+
+        final List<ReviewImageDto> reviewImageDtos = new ArrayList<>();
+        final Member mappedMember = getMappedMember(review, members);
+        final List<Image> mappedImages = getMappedImage(review, images);
+
+        for (Image mappedImage : mappedImages) {
+            reviewImageDtos.add(ReviewImageDto.of(mappedMember, mappedImage));
+        }
+
+        return reviewImageDtos;
     }
 }

--- a/src/main/java/org/prography/kagongsillok/review/application/ReviewService.java
+++ b/src/main/java/org/prography/kagongsillok/review/application/ReviewService.java
@@ -134,7 +134,7 @@ public class ReviewService {
                 .orElse(
                         Member.builder()
                                 .nickname("알 수 없음")
-                                .email("알 수 없음")
+                                .email("Unknown@unknown.com")
                                 .build()
                 );
     }

--- a/src/main/java/org/prography/kagongsillok/review/application/dto/ReviewImageDto.java
+++ b/src/main/java/org/prography/kagongsillok/review/application/dto/ReviewImageDto.java
@@ -1,0 +1,27 @@
+package org.prography.kagongsillok.review.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.prography.kagongsillok.image.domain.Image;
+import org.prography.kagongsillok.member.domain.Member;
+import org.prography.kagongsillok.review.domain.Review;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewImageDto {
+
+    private String imageUrl;
+    private String memberName;
+    private String memberProfileUrl;
+
+    private ReviewImageDto(final Member member, final Image image) {
+        this.imageUrl = image.getUrl();
+        this.memberName = member.getNickname();
+        this.memberProfileUrl = member.getProfileImageUrl();
+    }
+
+    public static ReviewImageDto of(Member member, Image image) {
+        return new ReviewImageDto(member, image);
+    }
+}

--- a/src/main/java/org/prography/kagongsillok/review/application/dto/ReviewImageListDto.java
+++ b/src/main/java/org/prography/kagongsillok/review/application/dto/ReviewImageListDto.java
@@ -7,17 +7,17 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ReviewImagesInfoDto {
+public class ReviewImageListDto {
 
     private int totalImageCount;
     private List<ReviewImageDto> reviewImageDtos;
 
-    private ReviewImagesInfoDto(final int totalImageCount, final List<ReviewImageDto> reviewImageDtos) {
+    private ReviewImageListDto(final int totalImageCount, final List<ReviewImageDto> reviewImageDtos) {
         this.totalImageCount = totalImageCount;
         this.reviewImageDtos = reviewImageDtos;
     }
 
-    public static ReviewImagesInfoDto of(final int totalImageCount, final List<ReviewImageDto> reviewImageDtos) {
-        return new ReviewImagesInfoDto(totalImageCount, reviewImageDtos);
+    public static ReviewImageListDto of(final int totalImageCount, final List<ReviewImageDto> reviewImageDtos) {
+        return new ReviewImageListDto(totalImageCount, reviewImageDtos);
     }
 }

--- a/src/main/java/org/prography/kagongsillok/review/application/dto/ReviewImagesInfoDto.java
+++ b/src/main/java/org/prography/kagongsillok/review/application/dto/ReviewImagesInfoDto.java
@@ -1,0 +1,23 @@
+package org.prography.kagongsillok.review.application.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewImagesInfoDto {
+
+    private int totalImageCount;
+    private List<ReviewImageDto> reviewImageDtos;
+
+    private ReviewImagesInfoDto(final int totalImageCount, final List<ReviewImageDto> reviewImageDtos) {
+        this.totalImageCount = totalImageCount;
+        this.reviewImageDtos = reviewImageDtos;
+    }
+
+    public static ReviewImagesInfoDto of(final int totalImageCount, final List<ReviewImageDto> reviewImageDtos) {
+        return new ReviewImagesInfoDto(totalImageCount, reviewImageDtos);
+    }
+}

--- a/src/main/java/org/prography/kagongsillok/review/ui/ReviewV1Controller.java
+++ b/src/main/java/org/prography/kagongsillok/review/ui/ReviewV1Controller.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.prography.kagongsillok.common.web.dto.CommonResponse;
 import org.prography.kagongsillok.review.application.ReviewService;
 import org.prography.kagongsillok.review.application.dto.ReviewDto;
-import org.prography.kagongsillok.review.application.dto.ReviewImagesInfoDto;
+import org.prography.kagongsillok.review.application.dto.ReviewImageListDto;
 import org.prography.kagongsillok.review.ui.dto.ReviewCreateRequest;
 import org.prography.kagongsillok.review.ui.dto.ReviewImagesInfoResponse;
 import org.prography.kagongsillok.review.ui.dto.ReviewListResponse;
@@ -81,7 +81,7 @@ public class ReviewV1Controller {
     public ResponseEntity<CommonResponse<ReviewImagesInfoResponse>> getPlaceReviewImages(
             @PathVariable("placeId") Long placeId
     ) {
-        final ReviewImagesInfoDto reviewImagesInfoDto = reviewService.getPlaceReviewImages(placeId);
-        return CommonResponse.success(ReviewImagesInfoResponse.from(reviewImagesInfoDto));
+        final ReviewImageListDto reviewImageListDto = reviewService.getPlaceReviewImages(placeId);
+        return CommonResponse.success(ReviewImagesInfoResponse.from(reviewImageListDto));
     }
 }

--- a/src/main/java/org/prography/kagongsillok/review/ui/ReviewV1Controller.java
+++ b/src/main/java/org/prography/kagongsillok/review/ui/ReviewV1Controller.java
@@ -5,7 +5,9 @@ import lombok.RequiredArgsConstructor;
 import org.prography.kagongsillok.common.web.dto.CommonResponse;
 import org.prography.kagongsillok.review.application.ReviewService;
 import org.prography.kagongsillok.review.application.dto.ReviewDto;
+import org.prography.kagongsillok.review.application.dto.ReviewImagesInfoDto;
 import org.prography.kagongsillok.review.ui.dto.ReviewCreateRequest;
+import org.prography.kagongsillok.review.ui.dto.ReviewImagesInfoResponse;
 import org.prography.kagongsillok.review.ui.dto.ReviewListResponse;
 import org.prography.kagongsillok.review.ui.dto.ReviewResponse;
 import org.prography.kagongsillok.review.ui.dto.ReviewUpdateRequest;
@@ -73,5 +75,13 @@ public class ReviewV1Controller {
     public ResponseEntity<Void> deleteReview(@PathVariable("reviewId") final Long id) {
         reviewService.deleteReview(id);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/images/{placeId}")
+    public ResponseEntity<CommonResponse<ReviewImagesInfoResponse>> getPlaceReviewImages(
+            @PathVariable("placeId") Long placeId
+    ) {
+        final ReviewImagesInfoDto reviewImagesInfoDto = reviewService.getPlaceReviewImages(placeId);
+        return CommonResponse.success(ReviewImagesInfoResponse.from(reviewImagesInfoDto));
     }
 }

--- a/src/main/java/org/prography/kagongsillok/review/ui/dto/ReviewImageResponse.java
+++ b/src/main/java/org/prography/kagongsillok/review/ui/dto/ReviewImageResponse.java
@@ -1,0 +1,25 @@
+package org.prography.kagongsillok.review.ui.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.prography.kagongsillok.review.application.dto.ReviewImageDto;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewImageResponse {
+
+    private String imageUrl;
+    private String memberName;
+    private String memberProfileUrl;
+
+    private ReviewImageResponse(final ReviewImageDto reviewImageDto) {
+        this.imageUrl = reviewImageDto.getImageUrl();
+        this.memberName = reviewImageDto.getMemberName();
+        this.memberProfileUrl = reviewImageDto.getMemberProfileUrl();
+    }
+
+    public static ReviewImageResponse from(final ReviewImageDto reviewImageDto) {
+        return new ReviewImageResponse(reviewImageDto);
+    }
+}

--- a/src/main/java/org/prography/kagongsillok/review/ui/dto/ReviewImagesInfoResponse.java
+++ b/src/main/java/org/prography/kagongsillok/review/ui/dto/ReviewImagesInfoResponse.java
@@ -1,0 +1,29 @@
+package org.prography.kagongsillok.review.ui.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.prography.kagongsillok.common.utils.CustomListUtils;
+import org.prography.kagongsillok.review.application.dto.ReviewImagesInfoDto;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReviewImagesInfoResponse {
+
+    private int totalImageCount;
+    private List<ReviewImageResponse> reviewImages;
+
+    private ReviewImagesInfoResponse(final ReviewImagesInfoDto reviewImagesInfoDto) {
+        this.totalImageCount = reviewImagesInfoDto.getTotalImageCount();
+        this.reviewImages = CustomListUtils.mapTo(
+                reviewImagesInfoDto.getReviewImageDtos(),
+                ReviewImageResponse::from
+        );
+    }
+
+    public static ReviewImagesInfoResponse from(final ReviewImagesInfoDto reviewImagesInfoDto) {
+        return new ReviewImagesInfoResponse(reviewImagesInfoDto);
+    }
+}

--- a/src/main/java/org/prography/kagongsillok/review/ui/dto/ReviewImagesInfoResponse.java
+++ b/src/main/java/org/prography/kagongsillok/review/ui/dto/ReviewImagesInfoResponse.java
@@ -2,11 +2,10 @@ package org.prography.kagongsillok.review.ui.dto;
 
 import java.util.List;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.prography.kagongsillok.common.utils.CustomListUtils;
-import org.prography.kagongsillok.review.application.dto.ReviewImagesInfoDto;
+import org.prography.kagongsillok.review.application.dto.ReviewImageListDto;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -15,15 +14,15 @@ public class ReviewImagesInfoResponse {
     private int totalImageCount;
     private List<ReviewImageResponse> reviewImages;
 
-    private ReviewImagesInfoResponse(final ReviewImagesInfoDto reviewImagesInfoDto) {
-        this.totalImageCount = reviewImagesInfoDto.getTotalImageCount();
+    private ReviewImagesInfoResponse(final ReviewImageListDto reviewImageListDto) {
+        this.totalImageCount = reviewImageListDto.getTotalImageCount();
         this.reviewImages = CustomListUtils.mapTo(
-                reviewImagesInfoDto.getReviewImageDtos(),
+                reviewImageListDto.getReviewImageDtos(),
                 ReviewImageResponse::from
         );
     }
 
-    public static ReviewImagesInfoResponse from(final ReviewImagesInfoDto reviewImagesInfoDto) {
-        return new ReviewImagesInfoResponse(reviewImagesInfoDto);
+    public static ReviewImagesInfoResponse from(final ReviewImageListDto reviewImageListDto) {
+        return new ReviewImagesInfoResponse(reviewImageListDto);
     }
 }

--- a/src/test/java/org/prography/kagongsillok/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/prography/kagongsillok/review/application/ReviewServiceTest.java
@@ -13,7 +13,7 @@ import org.prography.kagongsillok.member.domain.MemberRepository;
 import org.prography.kagongsillok.member.domain.Role;
 import org.prography.kagongsillok.review.application.dto.ReviewCreateCommand;
 import org.prography.kagongsillok.review.application.dto.ReviewDto;
-import org.prography.kagongsillok.review.application.dto.ReviewImagesInfoDto;
+import org.prography.kagongsillok.review.application.dto.ReviewImageListDto;
 import org.prography.kagongsillok.review.application.dto.ReviewUpdateCommand;
 import org.prography.kagongsillok.review.application.exception.NotFoundReviewException;
 import org.prography.kagongsillok.review.domain.ReviewTag;
@@ -287,18 +287,18 @@ public class ReviewServiceTest {
         reviewService.createReview(reviewCreateCommand1);
         reviewService.createReview(reviewCreateCommand2);
 
-        final ReviewImagesInfoDto reviewImagesInfoDto = reviewService.getPlaceReviewImages(placeId);
-        System.out.println(reviewImagesInfoDto);
+        final ReviewImageListDto reviewImageListDto = reviewService.getPlaceReviewImages(placeId);
+        System.out.println(reviewImageListDto);
 
         assertAll(
-                () -> assertThat(reviewImagesInfoDto.getReviewImageDtos().size()).isEqualTo(4),
-                () -> assertThat(reviewImagesInfoDto.getReviewImageDtos())
+                () -> assertThat(reviewImageListDto.getReviewImageDtos().size()).isEqualTo(4),
+                () -> assertThat(reviewImageListDto.getReviewImageDtos())
                         .extracting("imageUrl")
                         .containsAll(List.of("imageUrl1", "imageUrl2", "imageUrl3", "imageUrl4")),
-                () -> assertThat(reviewImagesInfoDto.getReviewImageDtos())
+                () -> assertThat(reviewImageListDto.getReviewImageDtos())
                         .extracting("memberName")
                         .containsAll(List.of("닉네임", "닉네임", "닉네임", "닉네임")),
-                () -> assertThat(reviewImagesInfoDto.getTotalImageCount()).isEqualTo(4)
+                () -> assertThat(reviewImageListDto.getTotalImageCount()).isEqualTo(4)
         );
     }
 

--- a/src/test/java/org/prography/kagongsillok/review/application/ReviewServiceTest.java
+++ b/src/test/java/org/prography/kagongsillok/review/application/ReviewServiceTest.java
@@ -6,11 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.prography.kagongsillok.image.domain.Image;
+import org.prography.kagongsillok.image.domain.ImageRepository;
 import org.prography.kagongsillok.member.domain.Member;
 import org.prography.kagongsillok.member.domain.MemberRepository;
 import org.prography.kagongsillok.member.domain.Role;
 import org.prography.kagongsillok.review.application.dto.ReviewCreateCommand;
 import org.prography.kagongsillok.review.application.dto.ReviewDto;
+import org.prography.kagongsillok.review.application.dto.ReviewImagesInfoDto;
 import org.prography.kagongsillok.review.application.dto.ReviewUpdateCommand;
 import org.prography.kagongsillok.review.application.exception.NotFoundReviewException;
 import org.prography.kagongsillok.review.domain.ReviewTag;
@@ -31,6 +34,9 @@ public class ReviewServiceTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private ImageRepository imageRepository;
 
     @Test
     void 리뷰를_생성한다() {
@@ -250,6 +256,52 @@ public class ReviewServiceTest {
         );
     }
 
+    @Test
+    void 장소_ID로_해당_장소_리뷰_이미지들을_조회한다() {
+        final Long memberId = saveMemberAndGetMemberId();
+        final Long placeId = 1L;
+        final Long tagId1 = saveTagAndGetTagId("#tag1");
+        final Long tagId2 = saveTagAndGetTagId("#tag2");
+        final Long imageId1 = saveImageAndGetImageId("imageUrl1");
+        final Long imageId2 = saveImageAndGetImageId("imageUrl2");
+        final Long imageId3 = saveImageAndGetImageId("imageUrl3");
+        final Long imageId4 = saveImageAndGetImageId("imageUrl4");
+        final ReviewCreateCommand reviewCreateCommand1 = ReviewCreateCommand
+                .builder()
+                .memberId(memberId)
+                .placeId(placeId)
+                .rating(5)
+                .content("test review1")
+                .imageIds(List.of(imageId1, imageId2))
+                .reviewTagIds(List.of(tagId1))
+                .build();
+        final ReviewCreateCommand reviewCreateCommand2 = ReviewCreateCommand
+                .builder()
+                .memberId(memberId)
+                .placeId(placeId)
+                .rating(1)
+                .content("test review2")
+                .imageIds(List.of(imageId3, imageId4))
+                .reviewTagIds(List.of(tagId2))
+                .build();
+        reviewService.createReview(reviewCreateCommand1);
+        reviewService.createReview(reviewCreateCommand2);
+
+        final ReviewImagesInfoDto reviewImagesInfoDto = reviewService.getPlaceReviewImages(placeId);
+        System.out.println(reviewImagesInfoDto);
+
+        assertAll(
+                () -> assertThat(reviewImagesInfoDto.getReviewImageDtos().size()).isEqualTo(4),
+                () -> assertThat(reviewImagesInfoDto.getReviewImageDtos())
+                        .extracting("imageUrl")
+                        .containsAll(List.of("imageUrl1", "imageUrl2", "imageUrl3", "imageUrl4")),
+                () -> assertThat(reviewImagesInfoDto.getReviewImageDtos())
+                        .extracting("memberName")
+                        .containsAll(List.of("닉네임", "닉네임", "닉네임", "닉네임")),
+                () -> assertThat(reviewImagesInfoDto.getTotalImageCount()).isEqualTo(4)
+        );
+    }
+
     private Long saveTagAndGetTagId(final String tagName) {
         final ReviewTag reviewTag1 = new ReviewTag(tagName, "test tag");
         return reviewTagRepository.save(reviewTag1).getId();
@@ -262,5 +314,15 @@ public class ReviewServiceTest {
                 .role(Role.MEMBER)
                 .build();
         return memberRepository.save(member).getId();
+    }
+
+    private Long saveImageAndGetImageId(final String imageUrl) {
+        final Image image = Image.builder()
+                .url(imageUrl)
+                .width(100)
+                .height(100)
+                .extension("extension")
+                .build();
+        return imageRepository.save(image).getId();
     }
 }


### PR DESCRIPTION
프론트에서 장소에 관련된 이미지들을 조회하는 API 요청해서 작업했습니다.
코드를 깔끔하게 짜보려했는데 어렵네용

가장 많이 고민했던 부분이 review 별로 memberId와 imageIds가 있는데 각각 review 별로 조회를 하면 쿼리 횟수가 너무 많아질 것 같아서 해당 place에 관련된 reivew의 memberId와 imageId를 모아서 한번에 조회하고 mapping 해주는 식으로 구현했습니다.
또한 나중에 pagenation이 필요할 것 같아서 totalImageCount를 따로 넣어주었습니다
보시고 리뷰 부탁드릴게요!