### PR TITLE
feat: 커버링 인덱스 적용으로 장소 검색 쿼리 성능 최적화

### DIFF
--- a/src/main/java/org/prography/kagongsillok/member/domain/dto/PlaceSurfaceInfo.java
+++ b/src/main/java/org/prography/kagongsillok/member/domain/dto/PlaceSurfaceInfo.java
@@ -1,0 +1,36 @@
+package org.prography.kagongsillok.member.domain.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PlaceSurfaceInfo {
+
+    private Long id;
+    private String name;
+    private String address;
+    private Double latitude;
+    private Double longitude;
+    private String phone;
+    private String thumbnailImageUrl;
+
+    public PlaceSurfaceInfo(
+            final Long id,
+            final String name,
+            final String address,
+            final Double latitude,
+            final Double longitude,
+            final String phone,
+            final String thumbnailImageUrl
+    ) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.phone = phone;
+        this.thumbnailImageUrl = thumbnailImageUrl;
+    }
+}

--- a/src/main/java/org/prography/kagongsillok/place/application/PlaceService.java
+++ b/src/main/java/org/prography/kagongsillok/place/application/PlaceService.java
@@ -7,13 +7,16 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
+import org.prography.kagongsillok.common.utils.CustomListUtils;
 import org.prography.kagongsillok.image.application.exception.NotFoundImageException;
 import org.prography.kagongsillok.image.domain.Image;
 import org.prography.kagongsillok.image.domain.ImageRepository;
+import org.prography.kagongsillok.member.domain.dto.PlaceSurfaceInfo;
 import org.prography.kagongsillok.place.application.dto.PlaceCreateCommand;
 import org.prography.kagongsillok.place.application.dto.PlaceDto;
 import org.prography.kagongsillok.place.application.dto.PlaceLocationAroundSearchCondition;
 import org.prography.kagongsillok.place.application.dto.PlaceSearchCondition;
+import org.prography.kagongsillok.place.application.dto.PlaceSurfaceDto;
 import org.prography.kagongsillok.place.application.dto.PlaceUpdateCommand;
 import org.prography.kagongsillok.place.application.exception.NotFoundPlaceException;
 import org.prography.kagongsillok.place.domain.Location;
@@ -79,15 +82,15 @@ public class PlaceService {
     }
 
     @Counted("counter.place")
-    public List<PlaceDto> searchPlaces(final PlaceSearchCondition searchCondition) {
-        final List<Place> places = placeRepository.searchPlace(
+    public List<PlaceSurfaceDto> searchPlaces(final PlaceSearchCondition searchCondition) {
+        final List<PlaceSurfaceInfo> places = placeRepository.searchPlace(
                 searchCondition.getName(),
                 Location.of(searchCondition.getLatitude(), searchCondition.getLongitude()),
                 searchCondition.getLatitudeBound(),
                 searchCondition.getLongitudeBound()
         );
 
-        return getPlaceDtos(places);
+        return CustomListUtils.mapTo(places, PlaceSurfaceDto::from);
     }
 
     @Transactional

--- a/src/main/java/org/prography/kagongsillok/place/application/PlaceService.java
+++ b/src/main/java/org/prography/kagongsillok/place/application/PlaceService.java
@@ -2,7 +2,6 @@ package org.prography.kagongsillok.place.application;
 
 import io.micrometer.core.annotation.Counted;
 import io.micrometer.core.annotation.Timed;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -14,6 +13,7 @@ import org.prography.kagongsillok.image.domain.ImageRepository;
 import org.prography.kagongsillok.place.application.dto.PlaceCreateCommand;
 import org.prography.kagongsillok.place.application.dto.PlaceDto;
 import org.prography.kagongsillok.place.application.dto.PlaceLocationAroundSearchCondition;
+import org.prography.kagongsillok.place.application.dto.PlaceSearchCondition;
 import org.prography.kagongsillok.place.application.dto.PlaceUpdateCommand;
 import org.prography.kagongsillok.place.application.exception.NotFoundPlaceException;
 import org.prography.kagongsillok.place.domain.Location;
@@ -79,8 +79,13 @@ public class PlaceService {
     }
 
     @Counted("counter.place")
-    public List<PlaceDto> searchPlacesByName(final String name) {
-        final List<Place> places = placeRepository.findByNameContains(name);
+    public List<PlaceDto> searchPlaces(final PlaceSearchCondition searchCondition) {
+        final List<Place> places = placeRepository.searchPlace(
+                searchCondition.getName(),
+                Location.of(searchCondition.getLatitude(), searchCondition.getLongitude()),
+                searchCondition.getLatitudeBound(),
+                searchCondition.getLongitudeBound()
+        );
 
         return getPlaceDtos(places);
     }

--- a/src/main/java/org/prography/kagongsillok/place/application/dto/PlaceSearchCondition.java
+++ b/src/main/java/org/prography/kagongsillok/place/application/dto/PlaceSearchCondition.java
@@ -1,0 +1,32 @@
+package org.prography.kagongsillok.place.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PlaceSearchCondition {
+
+    private Double latitude;
+    private Double longitude;
+    private Double latitudeBound;
+    private Double longitudeBound;
+    private String name;
+
+    @Builder
+    public PlaceSearchCondition(
+            final Double latitude,
+            final Double longitude,
+            final Double latitudeBound,
+            final Double longitudeBound,
+            final String name
+    ) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.latitudeBound = latitudeBound;
+        this.longitudeBound = longitudeBound;
+        this.name = name;
+    }
+}

--- a/src/main/java/org/prography/kagongsillok/place/application/dto/PlaceSurfaceDto.java
+++ b/src/main/java/org/prography/kagongsillok/place/application/dto/PlaceSurfaceDto.java
@@ -1,0 +1,51 @@
+package org.prography.kagongsillok.place.application.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.prography.kagongsillok.member.domain.dto.PlaceSurfaceInfo;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PlaceSurfaceDto {
+
+    private Long id;
+    private String name;
+    private String address;
+    private Double latitude;
+    private Double longitude;
+    private String phone;
+    private String thumbnailImageUrl;
+
+    @Builder
+    public PlaceSurfaceDto(
+            final Long id,
+            final String name,
+            final String address,
+            final Double latitude,
+            final Double longitude,
+            final String phone,
+            final String thumbnailImageUrl
+    ) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.phone = phone;
+        this.thumbnailImageUrl = thumbnailImageUrl;
+    }
+
+    public static PlaceSurfaceDto from(final PlaceSurfaceInfo placeInfo) {
+        return PlaceSurfaceDto.builder()
+                .id(placeInfo.getId())
+                .name(placeInfo.getName())
+                .address(placeInfo.getAddress())
+                .latitude(placeInfo.getLatitude())
+                .longitude(placeInfo.getLongitude())
+                .phone(placeInfo.getPhone())
+                .thumbnailImageUrl(placeInfo.getThumbnailImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/org/prography/kagongsillok/place/domain/Place.java
+++ b/src/main/java/org/prography/kagongsillok/place/domain/Place.java
@@ -6,6 +6,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,7 +20,10 @@ import org.prography.kagongsillok.common.utils.CustomStringUtils;
 
 @Getter
 @Entity
-@Table(name = "place")
+@Table(name = "place", indexes = {
+        @Index(name = "ix__place__for_search", columnList = "latitude, longitude, name, phone, address, thumbnail_image_url") // 커버링 인덱스
+        //@Index(name = "ix__place__for_search2", columnList = "latitude, longitude, name") // index condition pushdown 위해 name 포함
+})
 @Where(clause = "is_deleted = false")
 @SQLDelete(sql = "update place set is_deleted = true, updated_at = now() where id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/prography/kagongsillok/place/domain/Place.java
+++ b/src/main/java/org/prography/kagongsillok/place/domain/Place.java
@@ -21,7 +21,7 @@ import org.prography.kagongsillok.common.utils.CustomStringUtils;
 @Getter
 @Entity
 @Table(name = "place", indexes = {
-        @Index(name = "ix__place__for_search", columnList = "latitude, longitude, name, phone, address, thumbnail_image_url") // 커버링 인덱스
+        @Index(name = "ix__place__for_search", columnList = "latitude, longitude, name, phone, address, thumbnailImageUrl") // 커버링 인덱스
         //@Index(name = "ix__place__for_search2", columnList = "latitude, longitude, name") // index condition pushdown 위해 name 포함
 })
 @Where(clause = "is_deleted = false")

--- a/src/main/java/org/prography/kagongsillok/place/domain/Place.java
+++ b/src/main/java/org/prography/kagongsillok/place/domain/Place.java
@@ -33,7 +33,7 @@ public class Place extends AbstractRootEntity {
 
     @Embedded
     private Location location;
-
+    private String thumbnailImageUrl;
     private String imageIds; // 반정규화 컬럼 ex) 1,2,3
     private String phone;
 
@@ -49,6 +49,7 @@ public class Place extends AbstractRootEntity {
             final String address,
             final Double latitude,
             final Double longitude,
+            final String thumbnailImageUrl,
             final List<Long> imageIds,
             final String phone,
             final List<Link> links,
@@ -57,6 +58,7 @@ public class Place extends AbstractRootEntity {
         this.name = name;
         this.address = address;
         this.location = Location.of(latitude, longitude);
+        this.thumbnailImageUrl = thumbnailImageUrl;
         this.imageIds = CustomListUtils.joiningToString(imageIds, ",");
         this.phone = phone;
         this.links = Links.of(links);
@@ -68,6 +70,7 @@ public class Place extends AbstractRootEntity {
         this.address = target.address;
         this.location = target.location;
         this.imageIds = target.imageIds;
+        this.thumbnailImageUrl = target.thumbnailImageUrl;
         this.phone = target.phone;
         this.links.update(target.links);
         this.businessHours.update(target.businessHours);

--- a/src/main/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryCustom.java
+++ b/src/main/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryCustom.java
@@ -2,6 +2,7 @@ package org.prography.kagongsillok.place.infrastructure;
 
 import java.util.List;
 import java.util.Map;
+import org.prography.kagongsillok.member.domain.dto.PlaceSurfaceInfo;
 import org.prography.kagongsillok.place.domain.Location;
 import org.prography.kagongsillok.place.domain.Place;
 
@@ -13,7 +14,7 @@ public interface PlaceRepositoryCustom {
             final Double longitudeBound
     );
 
-    List<Place> searchPlace(
+    List<PlaceSurfaceInfo> searchPlace(
             final String name,
             final Location location,
             final Double latitudeBound,

--- a/src/main/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryCustom.java
+++ b/src/main/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryCustom.java
@@ -13,7 +13,12 @@ public interface PlaceRepositoryCustom {
             final Double longitudeBound
     );
 
-    List<Place> findByNameContains(final String name);
+    List<Place> searchPlace(
+            final String name,
+            final Location location,
+            final Double latitudeBound,
+            final Double longitudeBound
+    );
 
     List<Place> findByIdIn(final List<Long> placeIds);
 

--- a/src/main/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryImpl.java
+++ b/src/main/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryImpl.java
@@ -43,7 +43,12 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
     }
 
     @Override
-    public List<Place> findByNameContains(final String name) {
+    public List<Place> searchPlace(
+            final String name,
+            final Location location,
+            final Double latitudeBound,
+            final Double longitudeBound
+    ) {
         if (Objects.isNull(name)) {
             return List.of();
         }
@@ -51,6 +56,8 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         return queryFactory
                 .selectFrom(place)
                 .where(
+                        latitudeBetween(location, latitudeBound),
+                        longitudeBetween(location, longitudeBound),
                         nameContains(name),
                         isNotDeleted()
                 )

--- a/src/main/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryImpl.java
+++ b/src/main/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.prography.kagongsillok.place.infrastructure;
 
 import static org.prography.kagongsillok.place.domain.QPlace.place;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.prography.kagongsillok.member.domain.dto.PlaceSurfaceInfo;
 import org.prography.kagongsillok.place.domain.Location;
 import org.prography.kagongsillok.place.domain.Place;
 import org.springframework.stereotype.Repository;
@@ -18,7 +20,7 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
 
-    private static final int DEFAULT_SEARCH_RESULT_SIZE = 50;
+    private static final int DEFAULT_SEARCH_RESULT_SIZE = 500;
 
     private final JPAQueryFactory queryFactory;
 
@@ -43,7 +45,7 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
     }
 
     @Override
-    public List<Place> searchPlace(
+    public List<PlaceSurfaceInfo> searchPlace(
             final String name,
             final Location location,
             final Double latitudeBound,
@@ -54,7 +56,19 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         }
 
         return queryFactory
-                .selectFrom(place)
+                .select(
+                        Projections.constructor(
+                                PlaceSurfaceInfo.class,
+                                place.id,
+                                place.name,
+                                place.address,
+                                place.location.latitude,
+                                place.location.longitude,
+                                place.phone,
+                                place.thumbnailImageUrl
+                        )
+                )
+                .from(place)
                 .where(
                         latitudeBetween(location, latitudeBound),
                         longitudeBetween(location, longitudeBound),

--- a/src/main/java/org/prography/kagongsillok/place/ui/PlaceV1Controller.java
+++ b/src/main/java/org/prography/kagongsillok/place/ui/PlaceV1Controller.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.prography.kagongsillok.common.web.dto.CommonResponse;
 import org.prography.kagongsillok.place.application.PlaceService;
 import org.prography.kagongsillok.place.application.dto.PlaceDto;
+import org.prography.kagongsillok.place.application.dto.PlaceSearchCondition;
 import org.prography.kagongsillok.place.ui.dto.PlaceListResponse;
 import org.prography.kagongsillok.place.ui.dto.PlaceLocationAroundSearchRequest;
 import org.prography.kagongsillok.place.ui.dto.PlaceResponse;
@@ -45,8 +46,21 @@ public class PlaceV1Controller {
     }
 
     @GetMapping
-    public ResponseEntity<CommonResponse<PlaceListResponse>> searchTitle(@RequestParam final String title) {
-        final List<PlaceDto> placeDtos = placeService.searchPlacesByName(title);
+    public ResponseEntity<CommonResponse<PlaceListResponse>> searchTitle(
+            @RequestParam(defaultValue = "0.0") final Double latitude,
+            @RequestParam(defaultValue = "0.0") final Double longitude,
+            @RequestParam(defaultValue = "240.0") final Double latitudeBound,
+            @RequestParam(defaultValue = "180.0") final Double longitudeBound,
+            @RequestParam final String name
+    ) {
+        final PlaceSearchCondition searchCondition = PlaceSearchCondition.builder()
+                .latitude(latitude)
+                .longitude(longitude)
+                .latitudeBound(latitudeBound)
+                .longitudeBound(longitudeBound)
+                .name(name)
+                .build();
+        final List<PlaceDto> placeDtos = placeService.searchPlaces(searchCondition);
 
         return CommonResponse.success(PlaceListResponse.of(placeDtos));
     }

--- a/src/main/java/org/prography/kagongsillok/place/ui/PlaceV1Controller.java
+++ b/src/main/java/org/prography/kagongsillok/place/ui/PlaceV1Controller.java
@@ -6,9 +6,11 @@ import org.prography.kagongsillok.common.web.dto.CommonResponse;
 import org.prography.kagongsillok.place.application.PlaceService;
 import org.prography.kagongsillok.place.application.dto.PlaceDto;
 import org.prography.kagongsillok.place.application.dto.PlaceSearchCondition;
+import org.prography.kagongsillok.place.application.dto.PlaceSurfaceDto;
 import org.prography.kagongsillok.place.ui.dto.PlaceListResponse;
 import org.prography.kagongsillok.place.ui.dto.PlaceLocationAroundSearchRequest;
 import org.prography.kagongsillok.place.ui.dto.PlaceResponse;
+import org.prography.kagongsillok.place.ui.dto.PlaceSearchResultResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -46,7 +48,7 @@ public class PlaceV1Controller {
     }
 
     @GetMapping
-    public ResponseEntity<CommonResponse<PlaceListResponse>> searchTitle(
+    public ResponseEntity<CommonResponse<PlaceSearchResultResponse>> searchTitle(
             @RequestParam(defaultValue = "0.0") final Double latitude,
             @RequestParam(defaultValue = "0.0") final Double longitude,
             @RequestParam(defaultValue = "240.0") final Double latitudeBound,
@@ -60,9 +62,9 @@ public class PlaceV1Controller {
                 .longitudeBound(longitudeBound)
                 .name(name)
                 .build();
-        final List<PlaceDto> placeDtos = placeService.searchPlaces(searchCondition);
+        final List<PlaceSurfaceDto> placeDtos = placeService.searchPlaces(searchCondition);
 
-        return CommonResponse.success(PlaceListResponse.of(placeDtos));
+        return CommonResponse.success(PlaceSearchResultResponse.of(placeDtos));
     }
 
     @GetMapping("/tags")

--- a/src/main/java/org/prography/kagongsillok/place/ui/dto/PlaceSearchResultResponse.java
+++ b/src/main/java/org/prography/kagongsillok/place/ui/dto/PlaceSearchResultResponse.java
@@ -1,0 +1,21 @@
+package org.prography.kagongsillok.place.ui.dto;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.prography.kagongsillok.common.utils.CustomListUtils;
+import org.prography.kagongsillok.place.application.dto.PlaceSurfaceDto;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class PlaceSearchResultResponse {
+
+    private List<PlaceSurfaceResponse> places;
+
+    public static PlaceSearchResultResponse of (final List<PlaceSurfaceDto> placeDtos) {
+        return new PlaceSearchResultResponse(CustomListUtils.mapTo(placeDtos, PlaceSurfaceResponse::from));
+    }
+}

--- a/src/main/java/org/prography/kagongsillok/place/ui/dto/PlaceSurfaceResponse.java
+++ b/src/main/java/org/prography/kagongsillok/place/ui/dto/PlaceSurfaceResponse.java
@@ -1,0 +1,51 @@
+package org.prography.kagongsillok.place.ui.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.prography.kagongsillok.place.application.dto.PlaceSurfaceDto;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PlaceSurfaceResponse {
+
+    private Long id;
+    private String name;
+    private String address;
+    private Double latitude;
+    private Double longitude;
+    private String phone;
+    private String thumbnailImageUrl;
+
+    @Builder
+    public PlaceSurfaceResponse(
+            final Long id,
+            final String name,
+            final String address,
+            final Double latitude,
+            final Double longitude,
+            final String phone,
+            final String thumbnailImageUrl
+    ) {
+        this.id = id;
+        this.name = name;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.phone = phone;
+        this.thumbnailImageUrl = thumbnailImageUrl;
+    }
+
+    public static PlaceSurfaceResponse from(final PlaceSurfaceDto placeDto) {
+        return PlaceSurfaceResponse.builder()
+                .id(placeDto.getId())
+                .name(placeDto.getName())
+                .address(placeDto.getAddress())
+                .latitude(placeDto.getLatitude())
+                .longitude(placeDto.getLongitude())
+                .phone(placeDto.getPhone())
+                .thumbnailImageUrl(placeDto.getThumbnailImageUrl())
+                .build();
+    }
+}

--- a/src/test/java/org/prography/kagongsillok/acceptance/place/PlaceAcceptanceTest.java
+++ b/src/test/java/org/prography/kagongsillok/acceptance/place/PlaceAcceptanceTest.java
@@ -296,8 +296,10 @@ public class PlaceAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    private PlaceListResponse 장소_이름으로_검색_요청(final String title) {
-        return 응답_바디_추출(get(PLACE_API_BASE_URL_V1 + "?title=" + title), PlaceListResponse.class);
+    private PlaceListResponse 장소_이름으로_검색_요청(
+            final String name
+    ) {
+        return 응답_바디_추출(get(PLACE_API_BASE_URL_V1 + "?name=" + name), PlaceListResponse.class);
     }
 
     private static PlaceLocationAroundSearchRequest 탐색할_위도_경도_범위_생성(

--- a/src/test/java/org/prography/kagongsillok/acceptance/place/PlaceAcceptanceTest.java
+++ b/src/test/java/org/prography/kagongsillok/acceptance/place/PlaceAcceptanceTest.java
@@ -20,6 +20,7 @@ import org.prography.kagongsillok.place.ui.dto.PlaceCreateRequest;
 import org.prography.kagongsillok.place.ui.dto.PlaceListResponse;
 import org.prography.kagongsillok.place.ui.dto.PlaceLocationAroundSearchRequest;
 import org.prography.kagongsillok.place.ui.dto.PlaceResponse;
+import org.prography.kagongsillok.place.ui.dto.PlaceSearchResultResponse;
 import org.prography.kagongsillok.place.ui.dto.PlaceUpdateRequest;
 import org.prography.kagongsillok.review.ui.dto.ReviewCreateRequest;
 import org.prography.kagongsillok.review.ui.dto.ReviewResponse;
@@ -263,14 +264,14 @@ public class PlaceAcceptanceTest extends AcceptanceTest {
         return 응답_바디_추출(post(TAG_ADMIN_BASE_URL_V1, 태그_생성_요청_바디), ReviewTagResponse.class);
     }
 
-    private static void 없는_장소_이름으로_검색_검증(final PlaceListResponse 장소_이름으로_검색_응답1) {
+    private static void 없는_장소_이름으로_검색_검증(final PlaceSearchResultResponse 장소_이름으로_검색_응답1) {
         assertAll(
                 () -> assertThat(장소_이름으로_검색_응답1.getPlaces().size()).isEqualTo(0)
         );
     }
 
-    private static void 장소_이름으로_검색_검증(final PlaceListResponse 장소_이름으로_검색_응답1, final PlaceListResponse 장소_이름으로_검색_응답2,
-            final PlaceListResponse 장소_이름으로_검색_응답3) {
+    private static void 장소_이름으로_검색_검증(final PlaceSearchResultResponse 장소_이름으로_검색_응답1, final PlaceSearchResultResponse 장소_이름으로_검색_응답2,
+            final PlaceSearchResultResponse 장소_이름으로_검색_응답3) {
         assertAll(
                 () -> assertThat(장소_이름으로_검색_응답1.getPlaces().size()).isEqualTo(2),
                 () -> assertThat(장소_이름으로_검색_응답1.getPlaces()).extracting("name")
@@ -296,10 +297,10 @@ public class PlaceAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    private PlaceListResponse 장소_이름으로_검색_요청(
+    private PlaceSearchResultResponse 장소_이름으로_검색_요청(
             final String name
     ) {
-        return 응답_바디_추출(get(PLACE_API_BASE_URL_V1 + "?name=" + name), PlaceListResponse.class);
+        return 응답_바디_추출(get(PLACE_API_BASE_URL_V1 + "?name=" + name), PlaceSearchResultResponse.class);
     }
 
     private static PlaceLocationAroundSearchRequest 탐색할_위도_경도_범위_생성(

--- a/src/test/java/org/prography/kagongsillok/place/application/PlaceServiceTest.java
+++ b/src/test/java/org/prography/kagongsillok/place/application/PlaceServiceTest.java
@@ -16,6 +16,7 @@ import org.prography.kagongsillok.place.application.dto.PlaceCreateCommand.LinkC
 import org.prography.kagongsillok.place.application.dto.PlaceDto;
 import org.prography.kagongsillok.place.application.dto.PlaceLocationAroundSearchCondition;
 import org.prography.kagongsillok.place.application.dto.PlaceSearchCondition;
+import org.prography.kagongsillok.place.application.dto.PlaceSurfaceDto;
 import org.prography.kagongsillok.place.application.dto.PlaceUpdateCommand;
 import org.prography.kagongsillok.place.application.dto.PlaceUpdateCommand.BusinessHourUpdateCommand;
 import org.prography.kagongsillok.place.application.dto.PlaceUpdateCommand.LinkUpdateCommand;
@@ -394,7 +395,7 @@ class PlaceServiceTest {
                 .latitudeBound(10.0)
                 .longitudeBound(10.0)
                 .build();
-        List<PlaceDto> searchPlaces1 = placeService.searchPlaces(searchCondition);
+        List<PlaceSurfaceDto> searchPlaces1 = placeService.searchPlaces(searchCondition);
 
         assertAll(
                 () -> assertThat(searchPlaces1.size()).isEqualTo(2),

--- a/src/test/java/org/prography/kagongsillok/place/application/PlaceServiceTest.java
+++ b/src/test/java/org/prography/kagongsillok/place/application/PlaceServiceTest.java
@@ -15,6 +15,7 @@ import org.prography.kagongsillok.place.application.dto.PlaceCreateCommand.Busin
 import org.prography.kagongsillok.place.application.dto.PlaceCreateCommand.LinkCreateCommand;
 import org.prography.kagongsillok.place.application.dto.PlaceDto;
 import org.prography.kagongsillok.place.application.dto.PlaceLocationAroundSearchCondition;
+import org.prography.kagongsillok.place.application.dto.PlaceSearchCondition;
 import org.prography.kagongsillok.place.application.dto.PlaceUpdateCommand;
 import org.prography.kagongsillok.place.application.dto.PlaceUpdateCommand.BusinessHourUpdateCommand;
 import org.prography.kagongsillok.place.application.dto.PlaceUpdateCommand.LinkUpdateCommand;
@@ -352,7 +353,6 @@ class PlaceServiceTest {
     @Test
     void 장소_이름으로_장소를_검색한다() {
         final Long imageId = saveImageAndGetImageId("imageUrl1");
-        final String name1 = "테스트 카페1";
         final PlaceCreateCommand placeCreateCommand1 = PlaceCreateCommand.builder()
                 .name("테스트 카페1")
                 .address("테스트특별시 테스트구 테스트로 1004")
@@ -364,7 +364,7 @@ class PlaceServiceTest {
                 .businessHours(businessHourCreateCommands)
                 .build();
         final PlaceCreateCommand placeCreateCommand2 = PlaceCreateCommand.builder()
-                .name("테스트 카페1")
+                .name("테스트 카페2")
                 .address("테스트특별시 테스트구 테스트로 1004")
                 .latitude(-80.29)
                 .longitude(-60.298)
@@ -387,14 +387,18 @@ class PlaceServiceTest {
         placeService.createPlace(placeCreateCommand2);
         placeService.createPlace(placeCreateCommand3);
 
-        List<PlaceDto> searchPlaces1 = placeService.searchPlacesByName(name1);
+        final PlaceSearchCondition searchCondition = PlaceSearchCondition.builder()
+                .name("테스트 카페")
+                .latitude(-80.0)
+                .longitude(-60.0)
+                .latitudeBound(10.0)
+                .longitudeBound(10.0)
+                .build();
+        List<PlaceDto> searchPlaces1 = placeService.searchPlaces(searchCondition);
 
         assertAll(
                 () -> assertThat(searchPlaces1.size()).isEqualTo(2),
-                () -> assertThat(searchPlaces1).extracting("latitude")
-                        .containsAll(List.of(90.0, -80.29)),
-                () -> assertThat(searchPlaces1).extracting("longitude")
-                        .containsAll(List.of(120.129, -60.298))
+                () -> assertThat(searchPlaces1).extracting("name").contains("테스트 카페2", "테스트 카페3")
         );
     }
 

--- a/src/test/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryImplTest.java
+++ b/src/test/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryImplTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.prography.kagongsillok.member.domain.dto.PlaceSurfaceInfo;
 import org.prography.kagongsillok.place.application.dto.PlaceCreateCommand;
 import org.prography.kagongsillok.place.application.dto.PlaceCreateCommand.BusinessHourCreateCommand;
 import org.prography.kagongsillok.place.application.dto.PlaceCreateCommand.LinkCreateCommand;
@@ -171,7 +172,7 @@ public class PlaceRepositoryImplTest {
         placeRepository.save(placeCreateCommand3.toEntity());
         final String name1 = "테스트 장소2";
 
-        List<Place> places1 = placeRepositoryImpl.searchPlace(
+        List<PlaceSurfaceInfo> places1 = placeRepositoryImpl.searchPlace(
                 name1,
                 Location.of(49.66, 129.22),
                 5.0,
@@ -224,7 +225,7 @@ public class PlaceRepositoryImplTest {
         placeRepository.save(placeCreateCommand2.toEntity());
         placeRepository.save(placeCreateCommand3.toEntity());
 
-        List<Place> places1 = placeRepositoryImpl.searchPlace(
+        List<PlaceSurfaceInfo> places1 = placeRepositoryImpl.searchPlace(
                 "테스트 장소",
                 Location.of(49.66, 129.22),
                 5.0,

--- a/src/test/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryImplTest.java
+++ b/src/test/java/org/prography/kagongsillok/place/infrastructure/PlaceRepositoryImplTest.java
@@ -22,18 +22,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class PlaceRepositoryImplTest {
 
-    @Autowired
-    private PlaceRepositoryImpl placeRepositoryImpl;
-
-    @Autowired
-    private PlaceRepository placeRepository;
-
     private final List<LinkCreateCommand> linkCreateCommands = List.of(
             new LinkCreateCommand(LinkType.INSTAGRAM.name(), "testInstagramUrl"),
             new LinkCreateCommand(LinkType.BLOG.name(), "testBlogUrl"),
             new LinkCreateCommand(LinkType.WEB.name(), "testWebUrl")
     );
-
     private final List<BusinessHourCreateCommand> businessHourCreateCommands = List.of(
             new BusinessHourCreateCommand(
                     DayOfWeek.MONDAY.name(), LocalTime.of(12, 0), LocalTime.of(23, 59)
@@ -57,6 +50,10 @@ public class PlaceRepositoryImplTest {
                     DayOfWeek.SUNDAY.name(), LocalTime.of(12, 0), LocalTime.of(23, 59)
             )
     );
+    @Autowired
+    private PlaceRepositoryImpl placeRepositoryImpl;
+    @Autowired
+    private PlaceRepository placeRepository;
 
     @Test
     void 장소가_존재하도록_범위를_설정하고_위도_경도_주변_장소를_검색한다() {
@@ -138,7 +135,7 @@ public class PlaceRepositoryImplTest {
     void 정확한_장소_이름으로_장소를_검색한다() {
         final PlaceCreateCommand placeCreateCommand1 = PlaceCreateCommand
                 .builder()
-                .name("테스트 장소2")
+                .name("테스트 장소1")
                 .address("테스트특별시 테스트구")
                 .latitude(49.67)
                 .longitude(129.23)
@@ -151,57 +148,8 @@ public class PlaceRepositoryImplTest {
                 .builder()
                 .name("테스트 장소2")
                 .address("테스트특별시 테스트구")
-                .latitude(-49.67)
-                .longitude(-129.23)
-                .imageIds(List.of(1L, 2L, 3L))
-                .phone("testPhoneNumber")
-                .links(linkCreateCommands)
-                .businessHours(businessHourCreateCommands)
-                .build();
-        final PlaceCreateCommand placeCreateCommand3 = PlaceCreateCommand
-                .builder()
-                .name("테스트 장소2")
-                .address("테스트특별시 테스트구")
-                .latitude(16.67)
-                .longitude(-70.23)
-                .imageIds(List.of(1L, 2L, 3L))
-                .phone("testPhoneNumber")
-                .links(linkCreateCommands)
-                .businessHours(businessHourCreateCommands)
-                .build();
-        placeRepository.save(placeCreateCommand1.toEntity());
-        placeRepository.save(placeCreateCommand2.toEntity());
-        placeRepository.save(placeCreateCommand3.toEntity());
-        final String name1 = "테스트 장소2";
-
-        List<Place> places1 = placeRepositoryImpl.findByNameContains(name1);
-
-        assertAll(
-                () -> assertThat(places1.size()).isEqualTo(3),
-                () -> assertThat(places1).extracting("name")
-                        .containsAll(List.of("테스트 장소2", "테스트 장소2", "테스트 장소2"))
-        );
-    }
-
-    @Test
-    void 포함된_장소_이름으로_장소를_검색한다() {
-        final PlaceCreateCommand placeCreateCommand1 = PlaceCreateCommand
-                .builder()
-                .name("테스트 장소2")
-                .address("테스트특별시 테스트구")
-                .latitude(49.67)
-                .longitude(129.23)
-                .imageIds(List.of(1L, 2L, 3L))
-                .phone("testPhoneNumber")
-                .links(linkCreateCommands)
-                .businessHours(businessHourCreateCommands)
-                .build();
-        final PlaceCreateCommand placeCreateCommand2 = PlaceCreateCommand
-                .builder()
-                .name("테스트 장소2")
-                .address("테스트특별시 테스트구")
-                .latitude(-49.67)
-                .longitude(-129.23)
+                .latitude(49.66)
+                .longitude(129.22)
                 .imageIds(List.of(1L, 2L, 3L))
                 .phone("testPhoneNumber")
                 .links(linkCreateCommands)
@@ -221,14 +169,72 @@ public class PlaceRepositoryImplTest {
         placeRepository.save(placeCreateCommand1.toEntity());
         placeRepository.save(placeCreateCommand2.toEntity());
         placeRepository.save(placeCreateCommand3.toEntity());
-        final String name1 = "테스트";
+        final String name1 = "테스트 장소2";
 
-        List<Place> places1 = placeRepositoryImpl.findByNameContains(name1);
+        List<Place> places1 = placeRepositoryImpl.searchPlace(
+                name1,
+                Location.of(49.66, 129.22),
+                5.0,
+                5.0
+        );
 
         assertAll(
-                () -> assertThat(places1.size()).isEqualTo(3),
+                () -> assertThat(places1.size()).isEqualTo(1),
                 () -> assertThat(places1).extracting("name")
-                        .containsAll(List.of("테스트 장소2", "테스트 장소2", "테스트 장소3"))
+                        .containsAll(List.of("테스트 장소2"))
+        );
+    }
+
+    @Test
+    void 포함된_장소_이름으로_장소를_검색한다() {
+        final PlaceCreateCommand placeCreateCommand1 = PlaceCreateCommand
+                .builder()
+                .name("테스트 장소1")
+                .address("테스트특별시 테스트구")
+                .latitude(49.67)
+                .longitude(129.23)
+                .imageIds(List.of(1L, 2L, 3L))
+                .phone("testPhoneNumber")
+                .links(linkCreateCommands)
+                .businessHours(businessHourCreateCommands)
+                .build();
+        final PlaceCreateCommand placeCreateCommand2 = PlaceCreateCommand
+                .builder()
+                .name("테스트 장소2")
+                .address("테스트특별시 테스트구")
+                .latitude(49.66)
+                .longitude(129.22)
+                .imageIds(List.of(1L, 2L, 3L))
+                .phone("testPhoneNumber")
+                .links(linkCreateCommands)
+                .businessHours(businessHourCreateCommands)
+                .build();
+        final PlaceCreateCommand placeCreateCommand3 = PlaceCreateCommand
+                .builder()
+                .name("테스트 장소3")
+                .address("테스트특별시 테스트구")
+                .latitude(16.67)
+                .longitude(-70.23)
+                .imageIds(List.of(1L, 2L, 3L))
+                .phone("testPhoneNumber")
+                .links(linkCreateCommands)
+                .businessHours(businessHourCreateCommands)
+                .build();
+        placeRepository.save(placeCreateCommand1.toEntity());
+        placeRepository.save(placeCreateCommand2.toEntity());
+        placeRepository.save(placeCreateCommand3.toEntity());
+
+        List<Place> places1 = placeRepositoryImpl.searchPlace(
+                "테스트 장소",
+                Location.of(49.66, 129.22),
+                5.0,
+                5.0
+        );
+
+        assertAll(
+                () -> assertThat(places1.size()).isEqualTo(2),
+                () -> assertThat(places1).extracting("name")
+                        .containsAll(List.of("테스트 장소1", "테스트 장소2"))
         );
     }
 }


### PR DESCRIPTION
Place 검색 쿼리 최적화를 위해 인덱스 적용 방안 고민

1. 최소한의 조건절 인덱스만 걸고 ICP(index condition pushdown) 사용
2. 커버링 인덱스 사용

결과 2번 채택
이유: 수많은 실험 결과 조건이 구체적이고 결과 row 수가 적을 수록 1번이 빠르지만, 검색 범위가 넓고 결과 갯수가 많을 수록 점점 느려짐. 반면에 2번의 경우 꾸준하게 속도가 빠름. 어쨌든 랜덤 I/O가 발생하지 않는 커버링 인덱스가 조금 더 안정적으로 빠르다고 판단.
인덱스에 잡히는 컬럼이 많을 수록 쓰기 속도에 지연이 걱정될 수 있지만, 해당 테이블에 데이터가 삽입되는 일이 그리 많지 않기 때문에 조회성능의 안정성을 우선으로 선택. 2번의 경우 꾸준히 100ms대로 조회가 되지만, 1번의 경우 100ms ~ 400ms 대로 쿼리와 결과에 따라 응답속도가 불안정.

# 실험

실험 DB에 row 105만 개 적재 후 테스트.

## 인덱스 미적용 결과
```sql
select
    id, name, address, latitude, longitude, phone, thumbnail_image_url
from place
where (latitude between 90 and 90)
and (longitude between 60 and 60)
and name like '%테스트1113%'
limit 500;
```

![image](https://github.com/kagong-sillok/kagong-sillok-server/assets/63737500/48582256-5ab7-4679-b9a8-52804bdbe749)

5403ms


## 인덱스 생성
```sql
create index ix__place__for_search on place(latitude, longitude, name, phone, address, thumbnail_image_url); # 커버링 인덱스
create index ix__place__for_search2 on place(latitude, longitude, name); # ICP 활용
```

## ICP 활용

```sql
select
    id, name, address, latitude, longitude, phone, thumbnail_image_url
from place use index(ix__place__for_search2)
where (latitude between 90 and 90)
and (longitude between 60 and 60)
and name like '%테스트1113%'
limit 500;
```
![스크린샷 2023-09-29 오후 11 11 54](https://github.com/kagong-sillok/kagong-sillok-server/assets/63737500/613cf7ef-3f1d-44f3-91dd-af0ba5bf8f83)

### 실행계획
```json
{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "2936.34"
    },
    "table": {
      "table_name": "place",
      "access_type": "ref",
      "possible_keys": [
        "ix__place__for_search2"
      ],
      "key": "ix__place__for_search2",
      "used_key_parts": [
        "latitude",
        "longitude"
      ],
      "key_length": "18",
      "ref": [
        "const",
        "const"
      ],
      "rows_examined_per_scan": 2909,
      "rows_produced_per_join": 323,
      "filtered": "11.11",
      "index_condition": "((`chess`.`place`.`latitude` between 90 and 90) and (`chess`.`place`.`longitude` between 60 and 60) and (`chess`.`place`.`name` like '%테스트1113%'))",
      "cost_info": {
        "read_cost": "2645.45",
        "eval_cost": "32.32",
        "prefix_cost": "2936.35",
        "data_read_per_join": "1M"
      },
      "used_columns": [
        "id",
        "name",
        "address",
        "latitude",
        "longitude",
        "phone",
        "thumbnail_image_url"
      ]
    }
  }
}
```

### 조건절 범위 넓혀서 실행

```sql
select
    id, name, address, latitude, longitude, phone, thumbnail_image_url
from place use index(ix__place__for_search2)
where (latitude between 90 and 92)
and (longitude between 60 and 62)
and name like '%테스트11%'
limit 500;
```

![스크린샷 2023-09-29 오후 11 14 29](https://github.com/kagong-sillok/kagong-sillok-server/assets/63737500/90e0a241-7590-4b92-b5e1-144e08e662c5)

### 실행 계획

```json
{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "37033.34"
    },
    "table": {
      "table_name": "place",
      "access_type": "range",
      "possible_keys": [
        "ix__place__for_search2"
      ],
      "key": "ix__place__for_search2",
      "used_key_parts": [
        "latitude"
      ],
      "key_length": "18",
      "rows_examined_per_scan": 39792,
      "rows_produced_per_join": 491,
      "filtered": "1.23",
      "index_condition": "((`chess`.`place`.`latitude` between 90 and 92) and (`chess`.`place`.`longitude` between 60 and 62) and (`chess`.`place`.`name` like '%테스트11%'))",
      "using_MRR": true,
      "cost_info": {
        "read_cost": "36984.23",
        "eval_cost": "49.12",
        "prefix_cost": "37033.34",
        "data_read_per_join": "1M"
      },
      "used_columns": [
        "id",
        "name",
        "address",
        "latitude",
        "longitude",
        "phone",
        "thumbnail_image_url"
      ]
    }
  }
}
```

## 커버링 인덱스 사용

```sql
select
    id, name, address, latitude, longitude, phone, thumbnail_image_url
from place use index(ix__place__for_search)
where (latitude between 90 and 90)
and (longitude between 60 and 60)
and name like '%테스트1113%'
limit 500;
```

![스크린샷 2023-09-29 오후 11 17 15](https://github.com/kagong-sillok/kagong-sillok-server/assets/63737500/39d89f11-088f-4bfe-ba8a-a041817656ec)


### 실행계획

```json
{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "2465.47"
    },
    "table": {
      "table_name": "place",
      "access_type": "ref",
      "possible_keys": [
        "ix__place__for_search"
      ],
      "key": "ix__place__for_search",
      "used_key_parts": [
        "latitude",
        "longitude"
      ],
      "key_length": "18",
      "ref": [
        "const",
        "const"
      ],
      "rows_examined_per_scan": 5688,
      "rows_produced_per_join": 631,
      "filtered": "11.11",
      "using_index": true,
      "cost_info": {
        "read_cost": "1896.67",
        "eval_cost": "63.19",
        "prefix_cost": "2465.47",
        "data_read_per_join": "2M"
      },
      "used_columns": [
        "id",
        "name",
        "address",
        "latitude",
        "longitude",
        "phone",
        "thumbnail_image_url"
      ],
      "attached_condition": "((`chess`.`place`.`latitude` between 90 and 90) and (`chess`.`place`.`longitude` between 60 and 60) and (`chess`.`place`.`name` like '%테스트1113%'))"
    }
  }
}
```

## 범위 넓혀서 진행

```sql
select
    id, name, address, latitude, longitude, phone, thumbnail_image_url
from place use index(ix__place__for_search)
where (latitude between 90 and 92)
and (longitude between 60 and 62)
and name like '%테스트1%'
limit 500;
```

![스크린샷 2023-09-29 오후 11 20 05](https://github.com/kagong-sillok/kagong-sillok-server/assets/63737500/5b352b88-d1f7-456d-8acb-3baa46a2d1af)

실행 시간에 유의미한 차이가 없음

### 실행계획

```json
{
  "query_block": {
    "select_id": 1,
    "cost_info": {
      "query_cost": "21616.68"
    },
    "table": {
      "table_name": "place",
      "access_type": "range",
      "possible_keys": [
        "ix__place__for_search"
      ],
      "key": "ix__place__for_search",
      "used_key_parts": [
        "latitude"
      ],
      "key_length": "18",
      "rows_examined_per_scan": 40530,
      "rows_produced_per_join": 500,
      "filtered": "1.23",
      "using_index": true,
      "cost_info": {
        "read_cost": "21566.65",
        "eval_cost": "50.03",
        "prefix_cost": "21616.68",
        "data_read_per_join": "1M"
      },
      "used_columns": [
        "id",
        "name",
        "address",
        "latitude",
        "longitude",
        "phone",
        "thumbnail_image_url"
      ],
      "attached_condition": "((`chess`.`place`.`latitude` between 90 and 92) and (`chess`.`place`.`longitude` between 60 and 62) and (`chess`.`place`.`name` like '%테스트1%'))"
    }
  }
}
```

